### PR TITLE
feat: lift — Step → Cray の自然変換を公開APIにする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1474,6 +1475,7 @@
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1537,6 +1539,7 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -1741,6 +1744,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2053,6 +2057,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2445,6 +2450,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3330,6 +3336,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -4966,6 +4973,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5078,6 +5086,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -5164,6 +5173,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/core.ts
+++ b/src/core.ts
@@ -19,12 +19,12 @@ export type Cray<S = Record<string, unknown>, E = unknown> = (
   focus: Focus<S>,
 ) => Promise<Result<S, E>>;
 
-type StepReturn<S = Record<string, unknown>, E = unknown> =
+export type StepReturn<S = Record<string, unknown>, E = unknown> =
   | Result<S, E>
   | S
   | void
   | Promise<Result<S, E> | S | void>;
-type Step<S = Record<string, unknown>, E = unknown> = (
+export type Step<S = Record<string, unknown>, E = unknown> = (
   focus: Focus<S>,
 ) => StepReturn<S, E>;
 
@@ -142,6 +142,25 @@ function normalizeStep<S, E>(step: Step<S, E> | Cray<S, E>): Cray<S, E> {
 
   const wrapped: Cray<S, E> = (focus: Focus<S>) => runStep(step, focus);
   return withDefinition(wrapped, { kind: 'task', step: step as Step<S, E> });
+}
+
+/**
+ * Lift a plain Step into the Cray category.
+ *
+ * This is the natural transformation from the "loose step" category
+ * (where functions return `S | void | Result<S,E>`) into the "Cray" category
+ * (where functions return `Promise<Result<S,E>>`).
+ *
+ * The transformation:
+ * 1. Normalizes return values: `S | void | Result<S,E>` → `Result<S,E>`
+ * 2. Captures exceptions: `throw` → `Failure<S,E>`
+ * 3. Annotates with metadata: `CRAY_META` symbol for observability
+ * 4. Is idempotent: already-lifted `Cray` values pass through unchanged
+ */
+export function lift<S = Record<string, unknown>, E = unknown>(
+  step: Step<S, E> | Cray<S, E>,
+): Cray<S, E> {
+  return normalizeStep(step);
 }
 
 export function cray<S = Record<string, unknown>, E = unknown>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ export type {
   Success,
   Failure,
   Cray,
+  Step,
+  StepReturn,
   Reducer,
   Predicate,
   TaskDefinition,
@@ -13,7 +15,7 @@ export type {
   CrayDefinition,
   AnnotatedCray,
 } from './core';
-export { definitionOf, cray, elseCray, else_, parallel, branch } from './core';
+export { definitionOf, cray, lift, elseCray, else_, parallel, branch } from './core';
 export type { Graph, Node, ExecuteHooks } from './graph';
 export { compile, execute } from './graph';
 export { toMermaid } from './graphViz';

--- a/tests/lift.test.ts
+++ b/tests/lift.test.ts
@@ -1,0 +1,83 @@
+import { lay } from '@minamorl/lay';
+import { lift, cray, definitionOf } from '../src/core';
+import type { Cray } from '../src/core';
+
+describe('lift', () => {
+  test('normalizes a plain step into Cray', async () => {
+    type State = { value: number; doubled: number };
+    const step = (focus: ReturnType<typeof lay<State>>) => ({
+      ...focus.get(),
+      doubled: focus.get().value * 2,
+    });
+    const task = lift<State>(step);
+    const focus = lay<State>({ value: 21, doubled: 0 });
+    const result = await task(focus);
+    expect(result).toEqual({ ok: true, state: { value: 21, doubled: 42 } });
+  });
+
+  test('attaches CRAY_META with kind "task"', () => {
+    const step = () => ({ x: 1 });
+    const task = lift(step);
+    const def = definitionOf(task);
+    expect(def).toBeDefined();
+    expect(def?.kind).toBe('task');
+  });
+
+  test('is idempotent — lifting an already-lifted Cray returns the same value', () => {
+    const step = () => ({ x: 1 });
+    const first = lift(step);
+    const second = lift(first);
+    expect(first).toBe(second);
+  });
+
+  test('captures thrown errors as Failure', async () => {
+    const error = new Error('boom');
+    const step = () => {
+      throw error;
+    };
+    const task = lift<{ x: number }, Error>(step);
+    const result = await task(lay({ x: 0 }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe(error);
+    }
+  });
+
+  test('handles async steps', async () => {
+    const step = async (focus: ReturnType<typeof lay<{ n: number }>>) => {
+      await Promise.resolve();
+      return { n: focus.get().n + 10 };
+    };
+    const task = lift(step);
+    const result = await task(lay({ n: 5 }));
+    expect(result).toEqual({ ok: true, state: { n: 15 } });
+  });
+
+  test('handles void return (uses current state as fallback)', async () => {
+    const step = () => {
+      // side-effect only, no return
+    };
+    const task = lift<{ x: number }>(step);
+    const result = await task(lay({ x: 42 }));
+    expect(result).toEqual({ ok: true, state: { x: 42 } });
+  });
+
+  test('lifted step works inside cray() sequence', async () => {
+    const addOne = lift<number, string>((focus) => focus.get() + 1);
+    const double = lift<number, string>((focus) => focus.get() * 2);
+    const pipeline = cray<number, string>([addOne, double]);
+    const result = await pipeline(lay(3));
+    // (3 + 1) = 4, then 4 * 2 = 8
+    expect(result).toEqual({ ok: true, state: 8 });
+  });
+
+  test('lift and cray produce equivalent results for single steps', async () => {
+    const step = (focus: ReturnType<typeof lay<number>>) => focus.get() * 3;
+    const fromLift = lift<number, string>(step);
+    const fromCray = cray<number, string>(step);
+
+    const resultLift = await fromLift(lay(7));
+    const resultCray = await fromCray(lay(7));
+    expect(resultLift).toEqual(resultCray);
+  });
+});


### PR DESCRIPTION
## 概要

Issue #2 の実装。`normalizeStep` を `lift` として公開する。

### 変更内容

| ファイル | 変更 |
|---------|------|
| `src/core.ts` | `Step<S,E>`, `StepReturn<S,E>` を export化、`lift()` 関数追加 |
| `src/index.ts` | `lift`, `Step`, `StepReturn` の re-export 追加 |
| `tests/lift.test.ts` | lift 単体テスト 8件（新規） |

### lift が行う正規化

1. **戻り値の正規化**: `S | void | Result<S,E>` → `Result<S,E>`
2. **例外の捕捉**: `throw` → `Failure<S,E>`
3. **メタ情報の付与**: `CRAY_META` シンボルに記録（ExecuteHooks で自動観測可能）
4. **冪等性**: 既に lift 済みの Cray はそのまま返す

### テスト結果

- 既存テスト 58件: ✅ 全パス
- 新規 lift テスト 8件: ✅ 全パス
- `attach-cray.test.ts` は `@minamorl/root-core` 未インストールにより既存で失敗（本PR無関係）

### 実装変更量

**core.ts の既存コード変更: 0行（export 追加のみ）。新規コード: lift 関数 + JSDoc = ~18行。**

Closes #2